### PR TITLE
Add recovery endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,18 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-oauth2-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/src/main/java/eu/dissco/core/datacitepublisher/configuration/WebClientConfig.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/configuration/WebClientConfig.java
@@ -1,6 +1,7 @@
 package eu.dissco.core.datacitepublisher.configuration;
 
 import eu.dissco.core.datacitepublisher.properties.DataCiteConnectionProperties;
+import eu.dissco.core.datacitepublisher.properties.HandleConnectionProperties;
 import eu.dissco.core.datacitepublisher.web.WebClientUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -13,17 +14,29 @@ import org.springframework.web.reactive.function.client.WebClient;
 @RequiredArgsConstructor
 public class WebClientConfig {
 
-  private final DataCiteConnectionProperties properties;
-  @Bean
-  public WebClient webClient() {
+  private final DataCiteConnectionProperties dataciteProperties;
+  private final HandleConnectionProperties handleProperties;
+
+  @Bean("datacite")
+  public WebClient dataciteClient() {
     ExchangeFilterFunction errorResponseFilter = ExchangeFilterFunction
         .ofResponseProcessor(WebClientUtils::exchangeFilterResponseProcessor);
     return WebClient.builder()
-        .baseUrl(properties.getEndpoint())
+        .baseUrl(dataciteProperties.getEndpoint())
         .filter(errorResponseFilter)
         .defaultHeader(HttpHeaders.CONTENT_TYPE, "application/vnd.api+json")
         .defaultHeaders(
-            header -> header.setBasicAuth(properties.getRepositoryId(), properties.getPassword()))
+            header -> header.setBasicAuth(dataciteProperties.getRepositoryId(), dataciteProperties.getPassword()))
+        .build();
+  }
+
+  @Bean("handle")
+  public WebClient handleClient() {
+    ExchangeFilterFunction errorResponseFilter = ExchangeFilterFunction
+        .ofResponseProcessor(WebClientUtils::exchangeFilterResponseProcessor);
+    return WebClient.builder()
+        .baseUrl(handleProperties.getEndpoint())
+        .filter(errorResponseFilter)
         .build();
   }
 

--- a/src/main/java/eu/dissco/core/datacitepublisher/controller/RecoveryController.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/controller/RecoveryController.java
@@ -1,0 +1,32 @@
+package eu.dissco.core.datacitepublisher.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import eu.dissco.core.datacitepublisher.domain.RecoveryEvent;
+import eu.dissco.core.datacitepublisher.exceptions.DataCiteApiException;
+import eu.dissco.core.datacitepublisher.exceptions.HandleResolutionException;
+import eu.dissco.core.datacitepublisher.service.RecoveryService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/datacite-recovery")
+@RequiredArgsConstructor
+@Slf4j
+public class RecoveryController {
+
+  private final RecoveryService recoveryService;
+
+  @PostMapping("")
+  public ResponseEntity<Void> recoverPids(@RequestBody RecoveryEvent event)
+      throws HandleResolutionException, DataCiteApiException, JsonProcessingException {
+    recoveryService.recoverDataciteDois(event);
+    return ResponseEntity.ok(null);
+  }
+
+
+}

--- a/src/main/java/eu/dissco/core/datacitepublisher/domain/FdoType.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/domain/FdoType.java
@@ -1,0 +1,30 @@
+package eu.dissco.core.datacitepublisher.domain;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public enum FdoType {
+  @JsonProperty("https://hdl.handle.net/21.T11148/894b1e6cad57e921764e") DIGITAL_SPECIMEN,
+  @JsonProperty("https://hdl.handle.net/21.T11148/bbad8c4e101e8af01115") MEDIA_OBJECT;
+
+  public static FdoType fromString(String type) {
+    if ("https://hdl.handle.net/21.T11148/894b1e6cad57e921764e".equals(type)) {
+      return DIGITAL_SPECIMEN;
+    }
+    if ("https://hdl.handle.net/21.T11148/bbad8c4e101e8af01115".equals(type)) {
+      return MEDIA_OBJECT;
+    }
+    log.error("Invalid DOI type: {}", type);
+    throw new IllegalStateException();
+  }
+
+  @Override
+  public String toString(){
+    if (this.equals(DIGITAL_SPECIMEN)) return "https://hdl.handle.net/21.T11148/894b1e6cad57e921764e";
+    return "https://hdl.handle.net/21.T11148/bbad8c4e101e8af01115";
+  }
+
+
+}

--- a/src/main/java/eu/dissco/core/datacitepublisher/domain/RecoveryEvent.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/domain/RecoveryEvent.java
@@ -1,0 +1,10 @@
+package eu.dissco.core.datacitepublisher.domain;
+
+import java.util.List;
+
+public record RecoveryEvent(
+    List<String> handles,
+    EventType eventType
+) {
+
+}

--- a/src/main/java/eu/dissco/core/datacitepublisher/exceptions/HandleResolutionException.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/exceptions/HandleResolutionException.java
@@ -1,0 +1,9 @@
+package eu.dissco.core.datacitepublisher.exceptions;
+
+public class HandleResolutionException extends Exception {
+
+  public HandleResolutionException(){
+    super();
+  }
+
+}

--- a/src/main/java/eu/dissco/core/datacitepublisher/properties/HandleConnectionProperties.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/properties/HandleConnectionProperties.java
@@ -1,0 +1,16 @@
+package eu.dissco.core.datacitepublisher.properties;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Data
+@Validated
+@ConfigurationProperties("handle")
+public class HandleConnectionProperties {
+
+  @NotBlank
+  private String endpoint = "https://sandbox.dissco.tech/handle-manager/api/v1/pids/records";
+
+}

--- a/src/main/java/eu/dissco/core/datacitepublisher/properties/HandleConnectionProperties.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/properties/HandleConnectionProperties.java
@@ -1,6 +1,7 @@
 package eu.dissco.core.datacitepublisher.properties;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
@@ -12,5 +13,8 @@ public class HandleConnectionProperties {
 
   @NotBlank
   private String endpoint = "https://sandbox.dissco.tech/handle-manager/api/v1/pids/records";
+
+  @NotNull
+  private int maxHandles = 100;
 
 }

--- a/src/main/java/eu/dissco/core/datacitepublisher/security/JwtAuthConverter.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/security/JwtAuthConverter.java
@@ -1,0 +1,37 @@
+package eu.dissco.core.datacitepublisher.security;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimNames;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAuthConverter implements Converter<Jwt, AbstractAuthenticationToken> {
+    private final JwtGrantedAuthoritiesConverter jwtGrantedAuthoritiesConverter = new JwtGrantedAuthoritiesConverter();
+
+    @Override
+    public AbstractAuthenticationToken convert(@NotNull Jwt jwt) {
+        Collection<GrantedAuthority> authorities =
+                converterToStream(jwt).collect(Collectors.toSet());
+        return new JwtAuthenticationToken(jwt, authorities, getPrincipalClaimName(jwt));
+    }
+
+    private Stream<GrantedAuthority> converterToStream(Jwt jwt){
+        return Optional.of(jwtGrantedAuthoritiesConverter.convert(jwt)).stream()
+                .flatMap(Collection::stream);
+    }
+
+    private String getPrincipalClaimName(Jwt jwt) {
+        return jwt.getClaim(JwtClaimNames.SUB);
+    }
+
+}

--- a/src/main/java/eu/dissco/core/datacitepublisher/security/MethodSecurityConfig.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/security/MethodSecurityConfig.java
@@ -1,0 +1,19 @@
+package eu.dissco.core.datacitepublisher.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
+import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+
+@Configuration
+@EnableMethodSecurity
+public class MethodSecurityConfig {
+
+  @Bean
+  protected MethodSecurityExpressionHandler createExpressionHandler() {
+    return new DefaultMethodSecurityExpressionHandler();
+  }
+
+}
+

--- a/src/main/java/eu/dissco/core/datacitepublisher/security/WebSecurityConfig.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/security/WebSecurityConfig.java
@@ -1,0 +1,33 @@
+package eu.dissco.core.datacitepublisher.security;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@RequiredArgsConstructor
+@Configuration
+@EnableWebSecurity
+public class WebSecurityConfig  {
+
+  private final JwtAuthConverter jwtAuthConverter;
+
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http.authorizeHttpRequests(authorizeHttpRequests -> authorizeHttpRequests
+        .anyRequest().authenticated());
+
+    http.oauth2ResourceServer(jwtoauth2ResourceServer -> jwtoauth2ResourceServer.jwt((
+        jwt -> jwt.jwtAuthenticationConverter(jwtAuthConverter)
+    )));
+
+    http.sessionManagement(sessionManagement -> sessionManagement
+        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+    return http.build();
+  }
+
+}

--- a/src/main/java/eu/dissco/core/datacitepublisher/security/WebSecurityConfig.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/security/WebSecurityConfig.java
@@ -19,7 +19,8 @@ public class WebSecurityConfig  {
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
     http.authorizeHttpRequests(authorizeHttpRequests -> authorizeHttpRequests
-        .anyRequest().authenticated());
+        .anyRequest()
+        .hasRole("orchestration-admin"));
 
     http.oauth2ResourceServer(jwtoauth2ResourceServer -> jwtoauth2ResourceServer.jwt((
         jwt -> jwt.jwtAuthenticationConverter(jwtAuthConverter)

--- a/src/test/java/eu/dissco/core/datacitepublisher/TestUtils.java
+++ b/src/test/java/eu/dissco/core/datacitepublisher/TestUtils.java
@@ -359,6 +359,17 @@ public class TestUtils {
             .add(specimen2));
   }
 
+  public static JsonNode givenDigitalSpecimenPidRecordSingle(String pid) {
+    var specimen1 = MAPPER.createObjectNode()
+        .put("type", FdoType.DIGITAL_SPECIMEN.toString())
+        .set("attributes", MAPPER.valueToTree(givenDigitalSpecimen(pid)));
+
+    return MAPPER.createObjectNode()
+        .put("links", "https://dev.dissco.tech/api/v1/pids/records")
+        .set("data", MAPPER.createArrayNode()
+            .add(specimen1));
+  }
+
   public static JsonNode givenMediaObjectJson() {
     var media1 = MAPPER.createObjectNode()
         .put("type", FdoType.MEDIA_OBJECT.toString())

--- a/src/test/java/eu/dissco/core/datacitepublisher/controller/RecoveryControllerTest.java
+++ b/src/test/java/eu/dissco/core/datacitepublisher/controller/RecoveryControllerTest.java
@@ -1,0 +1,38 @@
+package eu.dissco.core.datacitepublisher.controller;
+
+import static eu.dissco.core.datacitepublisher.TestUtils.givenRecoveryEvent;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import eu.dissco.core.datacitepublisher.service.RecoveryService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+@ExtendWith(MockitoExtension.class)
+class RecoveryControllerTest {
+
+  @Mock
+  private RecoveryService recoveryService;
+
+  private RecoveryController recoveryController;
+
+  @BeforeEach
+  void init(){
+    recoveryController = new RecoveryController(recoveryService);
+  }
+
+  @Test
+  void testRecoverPids() throws Exception {
+    // Given
+
+    // When
+    var result = recoveryController.recoverPids(givenRecoveryEvent());
+
+    // Then
+    assertThat(result.getStatusCode()).isEqualTo(HttpStatus.OK);
+  }
+
+}

--- a/src/test/java/eu/dissco/core/datacitepublisher/domain/FdoTypeTest.java
+++ b/src/test/java/eu/dissco/core/datacitepublisher/domain/FdoTypeTest.java
@@ -1,0 +1,34 @@
+package eu.dissco.core.datacitepublisher.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class FdoTypeTest {
+
+  @Test
+  void testDsFromString(){
+    // When
+    var result = FdoType.fromString("https://hdl.handle.net/21.T11148/894b1e6cad57e921764e");
+
+    // Then
+    assertThat(result).isEqualTo(FdoType.DIGITAL_SPECIMEN);
+  }
+
+  @Test
+  void testMoFromString(){
+    // When
+    var result = FdoType.fromString("https://hdl.handle.net/21.T11148/bbad8c4e101e8af01115");
+
+    // Then
+    assertThat(result).isEqualTo(FdoType.MEDIA_OBJECT);
+  }
+
+  @Test
+  void testBadTypeFromString(){
+    // Then
+    assertThrows(IllegalStateException.class, () -> FdoType.fromString("Bad type"));
+  }
+
+}

--- a/src/test/java/eu/dissco/core/datacitepublisher/service/DataCitePublisherServiceTest.java
+++ b/src/test/java/eu/dissco/core/datacitepublisher/service/DataCitePublisherServiceTest.java
@@ -13,14 +13,15 @@ import static eu.dissco.core.datacitepublisher.TestUtils.givenMediaAttributes;
 import static eu.dissco.core.datacitepublisher.TestUtils.givenMediaAttributesFull;
 import static eu.dissco.core.datacitepublisher.TestUtils.givenMediaObject;
 import static eu.dissco.core.datacitepublisher.TestUtils.givenMediaObjectFull;
-import static eu.dissco.core.datacitepublisher.TestUtils.givenSpecimenAttributes;
-import static eu.dissco.core.datacitepublisher.TestUtils.givenSpecimenAttributesFull;
+import static eu.dissco.core.datacitepublisher.TestUtils.givenSpecimenDataCiteAttributes;
+import static eu.dissco.core.datacitepublisher.TestUtils.givenSpecimenDataCiteAttributesFull;
 import static eu.dissco.core.datacitepublisher.TestUtils.givenType;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.lenient;
 
+import eu.dissco.core.datacitepublisher.TestUtils;
 import eu.dissco.core.datacitepublisher.component.XmlLocReader;
 import eu.dissco.core.datacitepublisher.domain.DigitalSpecimenEvent;
 import eu.dissco.core.datacitepublisher.domain.EventType;
@@ -69,7 +70,7 @@ class DataCitePublisherServiceTest {
     var expected = MAPPER.valueToTree(
         DcRequest.builder()
             .data(DcData.builder()
-                .attributes(givenSpecimenAttributes())
+                .attributes(givenSpecimenDataCiteAttributes())
                 .build())
             .build());
     given(xmlLocReader.getLocationsFromXml(LOCS)).willReturn(LOCS_ARR);
@@ -88,7 +89,7 @@ class DataCitePublisherServiceTest {
     var expected = MAPPER.valueToTree(
         DcRequest.builder()
             .data(DcData.builder()
-                .attributes(givenSpecimenAttributes())
+                .attributes(givenSpecimenDataCiteAttributes())
                 .build())
             .build());
     given(xmlLocReader.getLocationsFromXml(LOCS)).willReturn(LOCS_ARR);
@@ -107,7 +108,7 @@ class DataCitePublisherServiceTest {
     var requestBody = MAPPER.valueToTree(
         DcRequest.builder()
             .data(DcData.builder()
-                .attributes(givenSpecimenAttributes())
+                .attributes(givenSpecimenDataCiteAttributes())
                 .build())
             .build());
     given(xmlLocReader.getLocationsFromXml(LOCS)).willReturn(LOCS_ARR);
@@ -125,7 +126,7 @@ class DataCitePublisherServiceTest {
     var expected = MAPPER.valueToTree(
         DcRequest.builder()
             .data(DcData.builder()
-                .attributes(givenSpecimenAttributesFull())
+                .attributes(givenSpecimenDataCiteAttributesFull())
                 .build())
             .build());
     given(xmlLocReader.getLocationsFromXml(LOCS)).willReturn(LOCS_ARR);
@@ -193,7 +194,7 @@ class DataCitePublisherServiceTest {
     var expected = MAPPER.valueToTree(
         DcRequest.builder()
             .data(DcData.builder()
-                .attributes(givenSpecimenAttributes(PREFIX + "/" + SUFFIX))
+                .attributes(TestUtils.givenSpecimenDataCiteAttributes(PREFIX + "/" + SUFFIX))
                 .build())
             .build());
     given(xmlLocReader.getLocationsFromXml(LOCS)).willReturn(LOCS_ARR);

--- a/src/test/java/eu/dissco/core/datacitepublisher/service/RecoveryServiceTest.java
+++ b/src/test/java/eu/dissco/core/datacitepublisher/service/RecoveryServiceTest.java
@@ -1,0 +1,105 @@
+package eu.dissco.core.datacitepublisher.service;
+
+import static eu.dissco.core.datacitepublisher.TestUtils.DOI;
+import static eu.dissco.core.datacitepublisher.TestUtils.DOI_ALT;
+import static eu.dissco.core.datacitepublisher.TestUtils.MAPPER;
+import static eu.dissco.core.datacitepublisher.TestUtils.PID_ALT;
+import static eu.dissco.core.datacitepublisher.TestUtils.givenDigitalSpecimen;
+import static eu.dissco.core.datacitepublisher.TestUtils.givenMediaObject;
+import static eu.dissco.core.datacitepublisher.TestUtils.givenMediaObjectJson;
+import static eu.dissco.core.datacitepublisher.TestUtils.givenRecoveryEvent;
+import static eu.dissco.core.datacitepublisher.TestUtils.givenDigitalSpecimenPidRecord;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import eu.dissco.core.datacitepublisher.domain.DigitalSpecimenEvent;
+import eu.dissco.core.datacitepublisher.domain.EventType;
+import eu.dissco.core.datacitepublisher.domain.MediaObjectEvent;
+import eu.dissco.core.datacitepublisher.exceptions.HandleResolutionException;
+import eu.dissco.core.datacitepublisher.web.HandleClient;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RecoveryServiceTest {
+
+  @Mock
+  private HandleClient handleClient;
+  @Mock
+  private DataCitePublisherService dataCitePublisherService;
+
+  private RecoveryService recoveryService;
+
+  @BeforeEach
+  void init() {
+    recoveryService = new RecoveryService(handleClient, dataCitePublisherService, MAPPER);
+  }
+
+  @Test
+  void testRecoverDoisSpecimen() throws Exception {
+    // Given
+    given(handleClient.resolveHandles(List.of(DOI, DOI_ALT)))
+        .willReturn(givenDigitalSpecimenPidRecord());
+
+    // When
+    recoveryService.recoverDataciteDois(givenRecoveryEvent());
+
+    // Then
+    then(dataCitePublisherService).should()
+        .handleMessages(new DigitalSpecimenEvent(givenDigitalSpecimen(), EventType.CREATE));
+    then(dataCitePublisherService).should()
+        .handleMessages(new DigitalSpecimenEvent(givenDigitalSpecimen(PID_ALT), EventType.CREATE));
+  }
+
+  @Test
+  void testRecoverDoisMedia() throws Exception {
+    // Given
+    given(handleClient.resolveHandles(List.of(DOI, DOI_ALT)))
+        .willReturn(givenMediaObjectJson());
+
+    // When
+    recoveryService.recoverDataciteDois(givenRecoveryEvent());
+
+    // Then
+    then(dataCitePublisherService).should()
+        .handleMessages(new MediaObjectEvent(givenMediaObject(), EventType.CREATE));
+    then(dataCitePublisherService).should()
+        .handleMessages(new MediaObjectEvent(givenMediaObject(PID_ALT), EventType.CREATE));
+  }
+
+  @Test
+  void testRecoverDoisMissingData() throws Exception {
+    // Given
+    var handleMessage = MAPPER.readTree("""
+        {
+          "links":"https://dev.dissco.tech/api/v1/pids/records"
+        }
+        """);
+    given(handleClient.resolveHandles(anyList())).willReturn(handleMessage);
+
+    // Then
+    assertThrows(HandleResolutionException.class, () -> recoveryService.recoverDataciteDois(givenRecoveryEvent()));
+  }
+
+  @Test
+  void testRecoverDoisDataNotArray() throws Exception {
+    // Given
+    var handleMessage = MAPPER.readTree("""
+        {
+          "links":"https://dev.dissco.tech/api/v1/pids/records",
+          "data": "yep"
+        }
+        """);
+    given(handleClient.resolveHandles(anyList())).willReturn(handleMessage);
+
+    // Then
+    assertThrows(HandleResolutionException.class, () -> recoveryService.recoverDataciteDois(givenRecoveryEvent()));
+  }
+
+}

--- a/src/test/java/eu/dissco/core/datacitepublisher/web/HandleClientTest.java
+++ b/src/test/java/eu/dissco/core/datacitepublisher/web/HandleClientTest.java
@@ -1,0 +1,100 @@
+package eu.dissco.core.datacitepublisher.web;
+
+import static eu.dissco.core.datacitepublisher.TestUtils.DOI;
+import static eu.dissco.core.datacitepublisher.TestUtils.DOI_ALT;
+import static eu.dissco.core.datacitepublisher.TestUtils.MAPPER;
+import static eu.dissco.core.datacitepublisher.TestUtils.givenDigitalSpecimenPidRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import eu.dissco.core.datacitepublisher.exceptions.HandleResolutionException;
+import java.io.IOException;
+import java.util.List;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@ExtendWith(MockitoExtension.class)
+class HandleClientTest {
+
+  private static MockWebServer mockHandleServer;
+  private HandleClient handleClient;
+
+  @BeforeAll
+  static void init() throws IOException {
+    mockHandleServer = new MockWebServer();
+    mockHandleServer.start();
+  }
+
+
+  @BeforeEach
+  void setup() {
+    ExchangeFilterFunction errorResponseFilter = ExchangeFilterFunction
+        .ofResponseProcessor(WebClientUtils::exchangeFilterResponseProcessor);
+    var client = WebClient.builder()
+        .baseUrl(String.format("http://%s:%s", mockHandleServer.getHostName(),
+            mockHandleServer.getPort()))
+        .filter(errorResponseFilter)
+        .build();
+    handleClient = new HandleClient(client);
+  }
+
+  @AfterAll
+  static void destroy() throws IOException {
+    mockHandleServer.shutdown();
+  }
+
+  @Test
+  void testResolveHandle() throws Exception {
+    //
+    mockHandleServer.enqueue(new MockResponse().setResponseCode(HttpStatus.OK.value())
+        .setBody(MAPPER.writeValueAsString(givenDigitalSpecimenPidRecord()))
+        .addHeader("Content-Type", "application/json"));
+
+    // When
+    var response = handleClient.resolveHandles(List.of(DOI, DOI_ALT));
+
+    // Then
+    assertThat(response).isEqualTo(givenDigitalSpecimenPidRecord());
+  }
+  
+  @Test
+  void testRetries(){
+    // Given
+    int requestCount = mockHandleServer.getRequestCount();
+    mockHandleServer.enqueue(new MockResponse().setResponseCode(501));
+    mockHandleServer.enqueue(new MockResponse().setResponseCode(501));
+    mockHandleServer.enqueue(new MockResponse().setResponseCode(501));
+    mockHandleServer.enqueue(new MockResponse().setResponseCode(501));
+
+    // When
+    assertThrows(HandleResolutionException.class,
+        () -> handleClient.resolveHandles(List.of(DOI)));
+    var newRequestCount = mockHandleServer.getRequestCount();
+
+    // Then
+    assertThat(newRequestCount - requestCount).isEqualTo(4);
+  }
+
+  @Test
+  void testInterruptedException() {
+    // Given
+    mockHandleServer.enqueue(new MockResponse().setResponseCode(HttpStatus.OK.value())
+        .addHeader("Content-Type", "application/json"));
+
+    Thread.currentThread().interrupt();
+
+    // When / Then
+    assertThrows(HandleResolutionException.class,
+        () -> handleClient.resolveHandles(List.of(DOI)));
+  }
+
+}


### PR DESCRIPTION
Adds endpoint that accepts a list of handles and creates a DOI through datacite. This intended to fix DOI issues post-ingestion.