### PR TITLE
web profile changes

### DIFF
--- a/.github/workflows/.trivyignore
+++ b/.github/workflows/.trivyignore
@@ -1,4 +1,0 @@
-# June 17
-# Issue with Tomcat - Spring needs to update
-
-CVE-2025-48988

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          distribution: 'oracle'
+          distribution: 'temurin'
           java-version: 21
       - name: Cache SonarCloud packages
         uses: actions/cache@v4
@@ -55,6 +55,9 @@ jobs:
           format: 'table'
           ignore-unfixed: true
           vuln-type: 'os,library'
+        env:
+          TRIVY_SKIP_DB_UPDATE: true
+          TRIVY_SKIP_JAVA_DB_UPDATE: true
       - name: Trivy - Stop on Severe Vulnerabilities
         uses: aquasecurity/trivy-action@master
         if: github.event_name == 'pull_request'
@@ -66,6 +69,9 @@ jobs:
           exit-code: '1'
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
+        env:
+          TRIVY_SKIP_DB_UPDATE: true
+          TRIVY_SKIP_JAVA_DB_UPDATE: true
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
-FROM eclipse-temurin:21-jdk-alpine as builder
+FROM eclipse-temurin:21-jdk-alpine AS builder
 WORKDIR application
 ARG JAR_FILE=target/*.jar
 COPY ${JAR_FILE} application.jar
 RUN java -Djarmode=layertools -jar application.jar extract
 
-FROM eclipse-temurin:21-jdk-alpine
-RUN adduser -D -u 1000 java
+FROM eclipse-temurin:21-jre-jammy
+RUN adduser --disabled-password -u 1000 java
 WORKDIR application
 COPY --chown=java:java --from=builder application/dependencies/ ./
 RUN true

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.0</version>
+    <version>3.5.8</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>eu.dissco.core</groupId>

--- a/src/main/java/eu/dissco/core/datacitepublisher/Profiles.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/Profiles.java
@@ -10,4 +10,5 @@ public class Profiles {
 
   public static final String TEST = "test";
   public static final String PUBLISH = "publish";
+  public static final String WEB = "web";
 }

--- a/src/main/java/eu/dissco/core/datacitepublisher/component/XmlLocReader.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/component/XmlLocReader.java
@@ -42,7 +42,8 @@ public class XmlLocReader {
         return location;
       }
     }
-    log.warn("Unable to find landing page location from 10320/loc in handle record. Using first value in field");
+    log.warn(
+        "Unable to find landing page location from 10320/loc in doi record. Using first value in field");
     return locations.getFirst();
   }
 

--- a/src/main/java/eu/dissco/core/datacitepublisher/configuration/DataCiteClientConfig.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/configuration/DataCiteClientConfig.java
@@ -2,7 +2,7 @@ package eu.dissco.core.datacitepublisher.configuration;
 
 import eu.dissco.core.datacitepublisher.Profiles;
 import eu.dissco.core.datacitepublisher.properties.DataCiteConnectionProperties;
-import eu.dissco.core.datacitepublisher.properties.HandleConnectionProperties;
+import eu.dissco.core.datacitepublisher.properties.DoiConnectionProperties;
 import eu.dissco.core.datacitepublisher.web.WebClientUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -18,7 +18,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 public class DataCiteClientConfig {
 
   private final DataCiteConnectionProperties dataciteProperties;
-  private final HandleConnectionProperties handleProperties;
+  private final DoiConnectionProperties doiConnProperties;
 
   @Bean("datacite")
   public WebClient dataciteClient() {
@@ -33,10 +33,10 @@ public class DataCiteClientConfig {
         .build();
   }
 
-  @Bean("handle")
-  public WebClient handleClient() {
+  @Bean("doi")
+  public WebClient doiClient() {
     return WebClient.builder()
-        .baseUrl(handleProperties.getEndpoint())
+        .baseUrl(doiConnProperties.getEndpoint())
         .build();
   }
 

--- a/src/main/java/eu/dissco/core/datacitepublisher/configuration/DataCiteClientConfig.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/configuration/DataCiteClientConfig.java
@@ -14,7 +14,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 @Configuration
 @RequiredArgsConstructor
-@Profile(Profiles.PUBLISH)
+@Profile({Profiles.PUBLISH, Profiles.WEB})
 public class DataCiteClientConfig {
 
   private final DataCiteConnectionProperties dataciteProperties;

--- a/src/main/java/eu/dissco/core/datacitepublisher/controller/RecoveryController.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/controller/RecoveryController.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import eu.dissco.core.datacitepublisher.Profiles;
 import eu.dissco.core.datacitepublisher.domain.RecoveryEvent;
 import eu.dissco.core.datacitepublisher.exceptions.DataCiteApiException;
-import eu.dissco.core.datacitepublisher.exceptions.HandleResolutionException;
+import eu.dissco.core.datacitepublisher.exceptions.DoiResolutionException;
 import eu.dissco.core.datacitepublisher.exceptions.InvalidRequestException;
 import eu.dissco.core.datacitepublisher.service.RecoveryService;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +27,7 @@ public class RecoveryController {
 
   @PostMapping("")
   public ResponseEntity<Void> recoverPids(@RequestBody RecoveryEvent event)
-      throws HandleResolutionException, DataCiteApiException, JsonProcessingException, InvalidRequestException {
+      throws DoiResolutionException, DataCiteApiException, JsonProcessingException, InvalidRequestException {
     recoveryService.recoverDataciteDois(event);
     return ResponseEntity.ok(null);
   }

--- a/src/main/java/eu/dissco/core/datacitepublisher/controller/RecoveryController.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/controller/RecoveryController.java
@@ -5,6 +5,7 @@ import eu.dissco.core.datacitepublisher.Profiles;
 import eu.dissco.core.datacitepublisher.domain.RecoveryEvent;
 import eu.dissco.core.datacitepublisher.exceptions.DataCiteApiException;
 import eu.dissco.core.datacitepublisher.exceptions.HandleResolutionException;
+import eu.dissco.core.datacitepublisher.exceptions.InvalidRequestException;
 import eu.dissco.core.datacitepublisher.service.RecoveryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -19,14 +20,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/datacite-recovery")
 @RequiredArgsConstructor
 @Slf4j
-@Profile(Profiles.PUBLISH)
+@Profile(Profiles.WEB)
 public class RecoveryController {
 
   private final RecoveryService recoveryService;
 
   @PostMapping("")
   public ResponseEntity<Void> recoverPids(@RequestBody RecoveryEvent event)
-      throws HandleResolutionException, DataCiteApiException, JsonProcessingException {
+      throws HandleResolutionException, DataCiteApiException, JsonProcessingException, InvalidRequestException {
     recoveryService.recoverDataciteDois(event);
     return ResponseEntity.ok(null);
   }

--- a/src/main/java/eu/dissco/core/datacitepublisher/domain/RecoveryEvent.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/domain/RecoveryEvent.java
@@ -3,7 +3,7 @@ package eu.dissco.core.datacitepublisher.domain;
 import java.util.List;
 
 public record RecoveryEvent(
-    List<String> handles,
+    List<String> dois,
     EventType eventType
 ) {
 

--- a/src/main/java/eu/dissco/core/datacitepublisher/domain/TombstoneEvent.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/domain/TombstoneEvent.java
@@ -5,7 +5,7 @@ import eu.dissco.core.datacitepublisher.domain.datacite.DcRelatedIdentifiers;
 import java.util.List;
 
 public record TombstoneEvent(
-    String handle,
+    String doi,
     @JsonProperty("dcRelatedIdentifiers")
     List<DcRelatedIdentifiers> dcRelatedIdentifiersTombstone) {
 

--- a/src/main/java/eu/dissco/core/datacitepublisher/exceptions/DataCiteConflictException.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/exceptions/DataCiteConflictException.java
@@ -1,0 +1,9 @@
+package eu.dissco.core.datacitepublisher.exceptions;
+
+public class DataCiteConflictException extends DataCiteApiException {
+
+  public DataCiteConflictException(String message) {
+    super(message);
+  }
+
+}

--- a/src/main/java/eu/dissco/core/datacitepublisher/exceptions/DoiResolutionException.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/exceptions/DoiResolutionException.java
@@ -1,0 +1,9 @@
+package eu.dissco.core.datacitepublisher.exceptions;
+
+public class DoiResolutionException extends Exception {
+
+  public DoiResolutionException() {
+    super();
+  }
+
+}

--- a/src/main/java/eu/dissco/core/datacitepublisher/exceptions/HandleResolutionException.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/exceptions/HandleResolutionException.java
@@ -1,9 +1,0 @@
-package eu.dissco.core.datacitepublisher.exceptions;
-
-public class HandleResolutionException extends Exception {
-
-  public HandleResolutionException(){
-    super();
-  }
-
-}

--- a/src/main/java/eu/dissco/core/datacitepublisher/exceptions/InvalidRequestException.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/exceptions/InvalidRequestException.java
@@ -5,4 +5,8 @@ public class InvalidRequestException extends Exception {
     super();
   }
 
+  public InvalidRequestException(String message) {
+    super(message);
+  }
+
 }

--- a/src/main/java/eu/dissco/core/datacitepublisher/properties/DataCiteConnectionProperties.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/properties/DataCiteConnectionProperties.java
@@ -10,7 +10,7 @@ import org.springframework.validation.annotation.Validated;
 @Data
 @Validated
 @ConfigurationProperties("datacite")
-@Profile(Profiles.PUBLISH)
+@Profile({Profiles.PUBLISH, Profiles.WEB})
 public class DataCiteConnectionProperties {
 
   @NotBlank

--- a/src/main/java/eu/dissco/core/datacitepublisher/properties/DoiConnectionProperties.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/properties/DoiConnectionProperties.java
@@ -10,14 +10,14 @@ import org.springframework.validation.annotation.Validated;
 
 @Data
 @Validated
-@ConfigurationProperties("handle")
+@ConfigurationProperties("pid")
 @Profile({Profiles.PUBLISH, Profiles.WEB})
-public class HandleConnectionProperties {
+public class DoiConnectionProperties {
 
   @NotBlank
   private String endpoint;
 
   @NotNull
-  private int maxHandles = 100;
+  private int maxDois = 100;
 
 }

--- a/src/main/java/eu/dissco/core/datacitepublisher/properties/HandleConnectionProperties.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/properties/HandleConnectionProperties.java
@@ -11,7 +11,7 @@ import org.springframework.validation.annotation.Validated;
 @Data
 @Validated
 @ConfigurationProperties("handle")
-@Profile(Profiles.PUBLISH)
+@Profile({Profiles.PUBLISH, Profiles.WEB})
 public class HandleConnectionProperties {
 
   @NotBlank

--- a/src/main/java/eu/dissco/core/datacitepublisher/security/JwtAuthConverter.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/security/JwtAuthConverter.java
@@ -16,7 +16,7 @@ import org.springframework.security.oauth2.server.resource.authentication.JwtAut
 import org.springframework.stereotype.Component;
 
 @Component
-@Profile(Profiles.PUBLISH)
+@Profile({Profiles.PUBLISH, Profiles.WEB})
 public class JwtAuthConverter implements Converter<Jwt, AbstractAuthenticationToken> {
 
     @Override

--- a/src/main/java/eu/dissco/core/datacitepublisher/security/MethodSecurityConfig.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/security/MethodSecurityConfig.java
@@ -10,7 +10,7 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 
 @Configuration
 @EnableMethodSecurity
-@Profile(Profiles.PUBLISH)
+@Profile({Profiles.PUBLISH, Profiles.WEB})
 public class MethodSecurityConfig {
 
   @Bean

--- a/src/main/java/eu/dissco/core/datacitepublisher/security/WebSecurityConfig.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/security/WebSecurityConfig.java
@@ -16,7 +16,7 @@ import org.springframework.security.web.SecurityFilterChain;
 @RequiredArgsConstructor
 @Configuration
 @EnableWebSecurity
-@Profile(Profiles.PUBLISH)
+@Profile({Profiles.PUBLISH, Profiles.WEB})
 public class WebSecurityConfig  {
 
   private final JwtAuthConverter jwtAuthConverter;

--- a/src/main/java/eu/dissco/core/datacitepublisher/service/DataCitePublisherService.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/service/DataCitePublisherService.java
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
-@Profile(Profiles.PUBLISH)
+@Profile({Profiles.PUBLISH, Profiles.WEB})
 public class DataCitePublisherService extends DataCiteService {
 
   @Qualifier("datacite")

--- a/src/main/java/eu/dissco/core/datacitepublisher/service/DataCitePublisherService.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/service/DataCitePublisherService.java
@@ -48,7 +48,7 @@ public class DataCitePublisherService extends DataCiteService {
 
   @Override
   public void tombstoneRecord(TombstoneEvent event) throws DataCiteApiException {
-    var dcRecord = dataCiteClient.getDoiRecord(event.handle());
+    var dcRecord = dataCiteClient.getDoiRecord(event.doi());
     var dcRequest = buildDataCiteTombstoneRequest(dcRecord, event);
     publishToDataCite(dcRequest, EventType.TOMBSTONE);
   }

--- a/src/main/java/eu/dissco/core/datacitepublisher/service/DataCiteService.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/service/DataCiteService.java
@@ -132,7 +132,7 @@ public abstract class DataCiteService {
                 .rightsList(getRights())
                 .relatedIdentifiers(relatedIdentifiers)
                 .dates(dates)
-                .doi(getDoi(event.handle()))
+                .doi(getDoi(event.doi()))
                 .build())
             .build())
         .build();

--- a/src/main/java/eu/dissco/core/datacitepublisher/service/RabbitMqConsumerService.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/service/RabbitMqConsumerService.java
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Service;
 @Profile({Profiles.PUBLISH, Profiles.TEST})
 public class RabbitMqConsumerService {
 
-  private static final String ERROR_MSG = "Unable to parse {} event from the handle API";
+  private static final String ERROR_MSG = "Unable to parse {} event from the doi API";
   @Qualifier("objectMapper")
   private final ObjectMapper mapper;
   private final DataCiteService service;

--- a/src/main/java/eu/dissco/core/datacitepublisher/service/RabbitMqConsumerService.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/service/RabbitMqConsumerService.java
@@ -2,6 +2,7 @@ package eu.dissco.core.datacitepublisher.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import eu.dissco.core.datacitepublisher.Profiles;
 import eu.dissco.core.datacitepublisher.domain.DigitalMediaEvent;
 import eu.dissco.core.datacitepublisher.domain.DigitalSpecimenEvent;
 import eu.dissco.core.datacitepublisher.domain.TombstoneEvent;
@@ -11,12 +12,14 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Profile;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Service;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
+@Profile({Profiles.PUBLISH, Profiles.TEST})
 public class RabbitMqConsumerService {
 
   private static final String ERROR_MSG = "Unable to parse {} event from the handle API";

--- a/src/main/java/eu/dissco/core/datacitepublisher/service/RecoveryService.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/service/RecoveryService.java
@@ -96,8 +96,9 @@ public class RecoveryService {
         dataCitePublisherService.handleMessages(
             new DigitalMediaEvent(mediaObject, EventType.UPDATE));
       }
+    } else {
+      dataCitePublisherService.handleMessages(new DigitalMediaEvent(mediaObject, eventType));
     }
-    dataCitePublisherService.handleMessages(new DigitalMediaEvent(mediaObject, eventType));
   }
 
 }

--- a/src/main/java/eu/dissco/core/datacitepublisher/service/RecoveryService.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/service/RecoveryService.java
@@ -50,7 +50,8 @@ public class RecoveryService {
   private void recoverDois(List<String> dois, EventType eventType)
       throws DoiResolutionException, DataCiteApiException, JsonProcessingException, InvalidRequestException {
     var handleResolutionResponse = handleClient.resolveDois(dois);
-    if (handleResolutionResponse.get("data") != null && handleResolutionResponse.get("data").isArray()) {
+    if (handleResolutionResponse.get("data") != null && handleResolutionResponse.get("data")
+        .isArray()) {
       var dataNodes = handleResolutionResponse.get("data");
       for (var pidRecordJson : dataNodes) {
         var type = FdoType.fromString(pidRecordJson.get("type").asText());
@@ -76,7 +77,6 @@ public class RecoveryService {
         dataCitePublisherService.handleMessages(
             new DigitalSpecimenEvent(digitalSpecimen, EventType.CREATE));
       } catch (DataCiteConflictException e) {
-        log.debug(e.getMessage());
         dataCitePublisherService.handleMessages(
             new DigitalSpecimenEvent(digitalSpecimen, EventType.UPDATE));
       }
@@ -88,6 +88,15 @@ public class RecoveryService {
   private void recoverDigitalMedia(JsonNode pidRecordAttributes, EventType eventType)
       throws DataCiteApiException, JsonProcessingException {
     var mediaObject = mapper.treeToValue(pidRecordAttributes, DigitalMedia.class);
+    if (eventType == null) {
+      try {
+        dataCitePublisherService.handleMessages(
+            new DigitalMediaEvent(mediaObject, EventType.CREATE));
+      } catch (DataCiteConflictException e) {
+        dataCitePublisherService.handleMessages(
+            new DigitalMediaEvent(mediaObject, EventType.UPDATE));
+      }
+    }
     dataCitePublisherService.handleMessages(new DigitalMediaEvent(mediaObject, eventType));
   }
 

--- a/src/main/java/eu/dissco/core/datacitepublisher/web/DoiClient.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/web/DoiClient.java
@@ -3,7 +3,7 @@ package eu.dissco.core.datacitepublisher.web;
 import com.fasterxml.jackson.databind.JsonNode;
 import eu.dissco.core.datacitepublisher.Profiles;
 import eu.dissco.core.datacitepublisher.exceptions.DataCiteApiException;
-import eu.dissco.core.datacitepublisher.exceptions.HandleResolutionException;
+import eu.dissco.core.datacitepublisher.exceptions.DoiResolutionException;
 import java.time.Duration;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -20,15 +20,15 @@ import reactor.util.retry.Retry;
 @Component
 @Slf4j
 @Profile({Profiles.PUBLISH, Profiles.WEB})
-public class HandleClient {
+public class DoiClient {
 
-  @Qualifier("handle")
+  @Qualifier("doi")
   private final WebClient webClient;
 
-  public JsonNode resolveHandles(List<String> handles) throws HandleResolutionException {
+  public JsonNode resolveDois(List<String> dois) throws DoiResolutionException {
     var response = webClient.method(HttpMethod.GET)
         .uri(uriBuilder -> uriBuilder
-            .queryParam("handles", handles)
+            .queryParam("handles", dois)
             .build())
         .retrieve()
         .bodyToMono(JsonNode.class)
@@ -41,11 +41,12 @@ public class HandleClient {
       return response.toFuture().get();
     } catch (InterruptedException e) {
       Thread.currentThread().interrupt();
-      log.error("An Interrupted Exception has occurred in communicating with the Handle Manager API.", e);
-      throw new HandleResolutionException();
+      log.error("An Interrupted Exception has occurred in communicating with the DOI Manager API.",
+          e);
+      throw new DoiResolutionException();
     } catch (ExecutionException e) {
-      log.error("An execution Exception with the Handle API has occurred", e);
-      throw new HandleResolutionException();
+      log.error("An execution Exception with the DOI API has occurred", e);
+      throw new DoiResolutionException();
     }
 
   }

--- a/src/main/java/eu/dissco/core/datacitepublisher/web/HandleClient.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/web/HandleClient.java
@@ -19,7 +19,7 @@ import reactor.util.retry.Retry;
 @RequiredArgsConstructor
 @Component
 @Slf4j
-@Profile(Profiles.PUBLISH)
+@Profile({Profiles.PUBLISH, Profiles.WEB})
 public class HandleClient {
 
   @Qualifier("handle")

--- a/src/test/java/eu/dissco/core/datacitepublisher/service/RecoveryServiceTest.java
+++ b/src/test/java/eu/dissco/core/datacitepublisher/service/RecoveryServiceTest.java
@@ -3,22 +3,20 @@ package eu.dissco.core.datacitepublisher.service;
 import static eu.dissco.core.datacitepublisher.TestUtils.DOI;
 import static eu.dissco.core.datacitepublisher.TestUtils.DOI_ALT;
 import static eu.dissco.core.datacitepublisher.TestUtils.MAPPER;
-import static eu.dissco.core.datacitepublisher.TestUtils.PID;
 import static eu.dissco.core.datacitepublisher.TestUtils.PID_ALT;
-import static eu.dissco.core.datacitepublisher.TestUtils.givenDigitalSpecimen;
-import static eu.dissco.core.datacitepublisher.TestUtils.givenDigitalSpecimenPidRecordSingle;
 import static eu.dissco.core.datacitepublisher.TestUtils.givenDigitalMedia;
 import static eu.dissco.core.datacitepublisher.TestUtils.givenDigitalMediaJson;
-import static eu.dissco.core.datacitepublisher.TestUtils.givenRecoveryEvent;
+import static eu.dissco.core.datacitepublisher.TestUtils.givenDigitalSpecimen;
 import static eu.dissco.core.datacitepublisher.TestUtils.givenDigitalSpecimenPidRecord;
+import static eu.dissco.core.datacitepublisher.TestUtils.givenRecoveryEvent;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
+import eu.dissco.core.datacitepublisher.domain.DigitalMediaEvent;
 import eu.dissco.core.datacitepublisher.domain.DigitalSpecimenEvent;
 import eu.dissco.core.datacitepublisher.domain.EventType;
-import eu.dissco.core.datacitepublisher.domain.DigitalMediaEvent;
 import eu.dissco.core.datacitepublisher.exceptions.HandleResolutionException;
 import eu.dissco.core.datacitepublisher.properties.HandleConnectionProperties;
 import eu.dissco.core.datacitepublisher.web.HandleClient;
@@ -52,25 +50,6 @@ class RecoveryServiceTest {
     given(handleClient.resolveHandles(List.of(DOI, DOI_ALT)))
         .willReturn(givenDigitalSpecimenPidRecord());
     given(handleConnectionProperties.getMaxHandles()).willReturn(10);
-
-    // When
-    recoveryService.recoverDataciteDois(givenRecoveryEvent());
-
-    // Then
-    then(dataCitePublisherService).should()
-        .handleMessages(new DigitalSpecimenEvent(givenDigitalSpecimen(), EventType.CREATE));
-    then(dataCitePublisherService).should()
-        .handleMessages(new DigitalSpecimenEvent(givenDigitalSpecimen(PID_ALT), EventType.CREATE));
-  }
-
-  @Test
-  void testRecoverDoisSpecimenTwoPages() throws Exception {
-    // Given
-    given(handleClient.resolveHandles(List.of(DOI)))
-        .willReturn(givenDigitalSpecimenPidRecordSingle(PID));
-    given(handleClient.resolveHandles(List.of(DOI_ALT)))
-        .willReturn(givenDigitalSpecimenPidRecordSingle(PID_ALT));
-    given(handleConnectionProperties.getMaxHandles()).willReturn(1);
 
     // When
     recoveryService.recoverDataciteDois(givenRecoveryEvent());

--- a/src/test/java/eu/dissco/core/datacitepublisher/service/RecoveryServiceTest.java
+++ b/src/test/java/eu/dissco/core/datacitepublisher/service/RecoveryServiceTest.java
@@ -17,9 +17,9 @@ import static org.mockito.BDDMockito.then;
 import eu.dissco.core.datacitepublisher.domain.DigitalMediaEvent;
 import eu.dissco.core.datacitepublisher.domain.DigitalSpecimenEvent;
 import eu.dissco.core.datacitepublisher.domain.EventType;
-import eu.dissco.core.datacitepublisher.exceptions.HandleResolutionException;
-import eu.dissco.core.datacitepublisher.properties.HandleConnectionProperties;
-import eu.dissco.core.datacitepublisher.web.HandleClient;
+import eu.dissco.core.datacitepublisher.exceptions.DoiResolutionException;
+import eu.dissco.core.datacitepublisher.properties.DoiConnectionProperties;
+import eu.dissco.core.datacitepublisher.web.DoiClient;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -31,11 +31,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class RecoveryServiceTest {
 
   @Mock
-  private HandleClient handleClient;
+  private DoiClient handleClient;
   @Mock
   private DataCitePublisherService dataCitePublisherService;
   @Mock
-  private HandleConnectionProperties handleConnectionProperties;
+  private DoiConnectionProperties handleConnectionProperties;
 
   private RecoveryService recoveryService;
 
@@ -47,9 +47,9 @@ class RecoveryServiceTest {
   @Test
   void testRecoverDoisSpecimen() throws Exception {
     // Given
-    given(handleClient.resolveHandles(List.of(DOI, DOI_ALT)))
+    given(handleClient.resolveDois(List.of(DOI, DOI_ALT)))
         .willReturn(givenDigitalSpecimenPidRecord());
-    given(handleConnectionProperties.getMaxHandles()).willReturn(10);
+    given(handleConnectionProperties.getMaxDois()).willReturn(10);
 
     // When
     recoveryService.recoverDataciteDois(givenRecoveryEvent());
@@ -64,9 +64,9 @@ class RecoveryServiceTest {
   @Test
   void testRecoverDoisMedia() throws Exception {
     // Given
-    given(handleClient.resolveHandles(List.of(DOI, DOI_ALT)))
+    given(handleClient.resolveDois(List.of(DOI, DOI_ALT)))
         .willReturn(givenDigitalMediaJson());
-    given(handleConnectionProperties.getMaxHandles()).willReturn(10);
+    given(handleConnectionProperties.getMaxDois()).willReturn(10);
 
     // When
     recoveryService.recoverDataciteDois(givenRecoveryEvent());
@@ -86,11 +86,12 @@ class RecoveryServiceTest {
           "links":"https://dev.dissco.tech/api/v1/pids/records"
         }
         """);
-    given(handleClient.resolveHandles(anyList())).willReturn(handleMessage);
-    given(handleConnectionProperties.getMaxHandles()).willReturn(10);
+    given(handleClient.resolveDois(anyList())).willReturn(handleMessage);
+    given(handleConnectionProperties.getMaxDois()).willReturn(10);
 
     // Then
-    assertThrows(HandleResolutionException.class, () -> recoveryService.recoverDataciteDois(givenRecoveryEvent()));
+    assertThrows(DoiResolutionException.class,
+        () -> recoveryService.recoverDataciteDois(givenRecoveryEvent()));
   }
 
   @Test
@@ -102,11 +103,12 @@ class RecoveryServiceTest {
           "data": "yep"
         }
         """);
-    given(handleClient.resolveHandles(anyList())).willReturn(handleMessage);
-    given(handleConnectionProperties.getMaxHandles()).willReturn(10);
+    given(handleClient.resolveDois(anyList())).willReturn(handleMessage);
+    given(handleConnectionProperties.getMaxDois()).willReturn(10);
 
     // Then
-    assertThrows(HandleResolutionException.class, () -> recoveryService.recoverDataciteDois(givenRecoveryEvent()));
+    assertThrows(DoiResolutionException.class,
+        () -> recoveryService.recoverDataciteDois(givenRecoveryEvent()));
   }
 
 }

--- a/src/test/java/eu/dissco/core/datacitepublisher/service/RecoveryServiceTest.java
+++ b/src/test/java/eu/dissco/core/datacitepublisher/service/RecoveryServiceTest.java
@@ -13,11 +13,15 @@ import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.doThrow;
 
 import eu.dissco.core.datacitepublisher.domain.DigitalMediaEvent;
 import eu.dissco.core.datacitepublisher.domain.DigitalSpecimenEvent;
 import eu.dissco.core.datacitepublisher.domain.EventType;
+import eu.dissco.core.datacitepublisher.domain.RecoveryEvent;
+import eu.dissco.core.datacitepublisher.exceptions.DataCiteConflictException;
 import eu.dissco.core.datacitepublisher.exceptions.DoiResolutionException;
+import eu.dissco.core.datacitepublisher.exceptions.InvalidRequestException;
 import eu.dissco.core.datacitepublisher.properties.DoiConnectionProperties;
 import eu.dissco.core.datacitepublisher.web.DoiClient;
 import java.util.List;
@@ -31,25 +35,26 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class RecoveryServiceTest {
 
   @Mock
-  private DoiClient handleClient;
+  private DoiClient doiClient;
   @Mock
   private DataCitePublisherService dataCitePublisherService;
   @Mock
-  private DoiConnectionProperties handleConnectionProperties;
+  private DoiConnectionProperties doiConnectionProperties;
 
   private RecoveryService recoveryService;
 
   @BeforeEach
   void init() {
-    recoveryService = new RecoveryService(handleClient, dataCitePublisherService, MAPPER, handleConnectionProperties);
+    recoveryService = new RecoveryService(doiClient, dataCitePublisherService, MAPPER,
+        doiConnectionProperties);
   }
 
   @Test
   void testRecoverDoisSpecimen() throws Exception {
     // Given
-    given(handleClient.resolveDois(List.of(DOI, DOI_ALT)))
+    given(doiClient.resolveDois(List.of(DOI, DOI_ALT)))
         .willReturn(givenDigitalSpecimenPidRecord());
-    given(handleConnectionProperties.getMaxDois()).willReturn(10);
+    given(doiConnectionProperties.getMaxDois()).willReturn(10);
 
     // When
     recoveryService.recoverDataciteDois(givenRecoveryEvent());
@@ -62,11 +67,32 @@ class RecoveryServiceTest {
   }
 
   @Test
+  void testRecoverDoisSpecimenUnknownEventType() throws Exception {
+    // Given
+    given(doiClient.resolveDois(List.of(DOI, DOI_ALT)))
+        .willReturn(givenDigitalSpecimenPidRecord());
+    given(doiConnectionProperties.getMaxDois()).willReturn(10);
+    var event = new RecoveryEvent(List.of(DOI, DOI_ALT), null);
+    var createEvent = new DigitalSpecimenEvent(givenDigitalSpecimen(), EventType.CREATE);
+    doThrow(DataCiteConflictException.class).when(dataCitePublisherService)
+        .handleMessages(createEvent);
+
+    // When
+    recoveryService.recoverDataciteDois(event);
+
+    // Then
+    then(dataCitePublisherService).should()
+        .handleMessages(new DigitalSpecimenEvent(givenDigitalSpecimen(), EventType.UPDATE));
+    then(dataCitePublisherService).should()
+        .handleMessages(new DigitalSpecimenEvent(givenDigitalSpecimen(PID_ALT), EventType.CREATE));
+  }
+
+  @Test
   void testRecoverDoisMedia() throws Exception {
     // Given
-    given(handleClient.resolveDois(List.of(DOI, DOI_ALT)))
+    given(doiClient.resolveDois(List.of(DOI, DOI_ALT)))
         .willReturn(givenDigitalMediaJson());
-    given(handleConnectionProperties.getMaxDois()).willReturn(10);
+    given(doiConnectionProperties.getMaxDois()).willReturn(10);
 
     // When
     recoveryService.recoverDataciteDois(givenRecoveryEvent());
@@ -79,15 +105,48 @@ class RecoveryServiceTest {
   }
 
   @Test
+  void testRecoverDoisMediaUnknownEventType() throws Exception {
+    // Given
+    given(doiClient.resolveDois(List.of(DOI, DOI_ALT)))
+        .willReturn(givenDigitalMediaJson());
+    given(doiConnectionProperties.getMaxDois()).willReturn(10);
+    var event = new RecoveryEvent(List.of(DOI, DOI_ALT), null);
+    var createEvent = new DigitalMediaEvent(givenDigitalMedia(), EventType.CREATE);
+    doThrow(DataCiteConflictException.class).when(dataCitePublisherService)
+        .handleMessages(createEvent);
+
+    // When
+    recoveryService.recoverDataciteDois(event);
+
+    // Then
+    then(dataCitePublisherService).should()
+        .handleMessages(new DigitalMediaEvent(givenDigitalMedia(), EventType.UPDATE));
+    then(dataCitePublisherService).should()
+        .handleMessages(new DigitalMediaEvent(givenDigitalMedia(PID_ALT), EventType.CREATE));
+  }
+
+  @Test
+  void testRecoverDoisSpecimenTwoPages() {
+    // Given
+    given(doiConnectionProperties.getMaxDois()).willReturn(1);
+    var event = new RecoveryEvent(
+        List.of(DOI, DOI_ALT), EventType.CREATE
+    );
+
+    // When / then
+    assertThrows(InvalidRequestException.class, () -> recoveryService.recoverDataciteDois(event));
+  }
+
+  @Test
   void testRecoverDoisMissingData() throws Exception {
     // Given
-    var handleMessage = MAPPER.readTree("""
+    var doiMessage = MAPPER.readTree("""
         {
           "links":"https://dev.dissco.tech/api/v1/pids/records"
         }
         """);
-    given(handleClient.resolveDois(anyList())).willReturn(handleMessage);
-    given(handleConnectionProperties.getMaxDois()).willReturn(10);
+    given(doiClient.resolveDois(anyList())).willReturn(doiMessage);
+    given(doiConnectionProperties.getMaxDois()).willReturn(10);
 
     // Then
     assertThrows(DoiResolutionException.class,
@@ -97,14 +156,14 @@ class RecoveryServiceTest {
   @Test
   void testRecoverDoisDataNotArray() throws Exception {
     // Given
-    var handleMessage = MAPPER.readTree("""
+    var doiMessage = MAPPER.readTree("""
         {
           "links":"https://dev.dissco.tech/api/v1/pids/records",
           "data": "yep"
         }
         """);
-    given(handleClient.resolveDois(anyList())).willReturn(handleMessage);
-    given(handleConnectionProperties.getMaxDois()).willReturn(10);
+    given(doiClient.resolveDois(anyList())).willReturn(doiMessage);
+    given(doiConnectionProperties.getMaxDois()).willReturn(10);
 
     // Then
     assertThrows(DoiResolutionException.class,

--- a/src/test/java/eu/dissco/core/datacitepublisher/web/HandleClientTest.java
+++ b/src/test/java/eu/dissco/core/datacitepublisher/web/HandleClientTest.java
@@ -7,7 +7,7 @@ import static eu.dissco.core.datacitepublisher.TestUtils.givenDigitalSpecimenPid
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 
-import eu.dissco.core.datacitepublisher.exceptions.HandleResolutionException;
+import eu.dissco.core.datacitepublisher.exceptions.DoiResolutionException;
 import java.io.IOException;
 import java.util.List;
 import okhttp3.mockwebserver.MockResponse;
@@ -25,7 +25,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 class HandleClientTest {
 
   private static MockWebServer mockHandleServer;
-  private HandleClient handleClient;
+  private DoiClient handleClient;
 
   @BeforeAll
   static void init() throws IOException {
@@ -40,7 +40,7 @@ class HandleClientTest {
         .baseUrl(String.format("http://%s:%s", mockHandleServer.getHostName(),
             mockHandleServer.getPort()))
         .build();
-    handleClient = new HandleClient(client);
+    handleClient = new DoiClient(client);
   }
 
   @AfterAll
@@ -56,7 +56,7 @@ class HandleClientTest {
         .addHeader("Content-Type", "application/json"));
 
     // When
-    var response = handleClient.resolveHandles(List.of(DOI, DOI_ALT));
+    var response = handleClient.resolveDois(List.of(DOI, DOI_ALT));
 
     // Then
     assertThat(response).isEqualTo(givenDigitalSpecimenPidRecord());
@@ -72,8 +72,8 @@ class HandleClientTest {
     mockHandleServer.enqueue(new MockResponse().setResponseCode(501));
 
     // When
-    assertThrows(HandleResolutionException.class,
-        () -> handleClient.resolveHandles(List.of(DOI)));
+    assertThrows(DoiResolutionException.class,
+        () -> handleClient.resolveDois(List.of(DOI)));
     var newRequestCount = mockHandleServer.getRequestCount();
 
     // Then
@@ -89,8 +89,8 @@ class HandleClientTest {
     Thread.currentThread().interrupt();
 
     // When / Then
-    assertThrows(HandleResolutionException.class,
-        () -> handleClient.resolveHandles(List.of(DOI)));
+    assertThrows(DoiResolutionException.class,
+        () -> handleClient.resolveDois(List.of(DOI)));
   }
 
 }


### PR DESCRIPTION
**New profile: web**
- Introduces new profile: web
- This profile is (currently) only for using the recovery api. no rabbitmq listeners

**Unknown event type recovery**
- For if you don't know if the record made it into datacite.
- tries creating new datacite record; if it fails as a result of a conflict, we try an update instead. 

**Misc Improvements**
- Adds invalid request exception for api
- removes pagination if the client requests recovery of too many handles -- throws exception
- uses "doi" in place of "handle"

**Deployment changes**
- Rename "handle" application property to "pid"