### PR TITLE
remove profiles

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,9 @@ on:
       - main
   pull_request:
     types: [ opened, synchronize, reopened ]
+  schedule:
+    - cron: "0 4  * * MON" # run on Monday at 4 AM
+  workflow_dispatch:  # Allow manual triggering
 jobs:
   build:
     name: Build
@@ -60,7 +63,7 @@ jobs:
           TRIVY_SKIP_JAVA_DB_UPDATE: true
       - name: Trivy - Stop on Severe Vulnerabilities
         uses: aquasecurity/trivy-action@master
-        if: github.event_name == 'pull_request'
+        if: github.event_name != 'push'
         with:
           image-ref: '${{ github.event.repository.name }}'
           format: 'table'
@@ -84,15 +87,26 @@ jobs:
         uses: docker/build-push-action@v3
         with:
           context: .
-          push: ${{ github.event_name != 'pull_request' }}
+          push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: Set outputs
         id: vars
         run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
       - name: Push tag
-        if: github.event_name != 'pull_request'
+        if: github.event_name == 'push'
         uses: anothrNick/github-tag-action@1.70.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CUSTOM_TAG: sha-${{ steps.vars.outputs.sha_short }}
+  scan:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.5.8</version>
+    <version>3.5.10</version>
     <relativePath/> <!-- lookup parent from repository -->
   </parent>
   <groupId>eu.dissco.core</groupId>

--- a/src/main/java/eu/dissco/core/datacitepublisher/security/WebSecurityConfig.java
+++ b/src/main/java/eu/dissco/core/datacitepublisher/security/WebSecurityConfig.java
@@ -1,13 +1,11 @@
 package eu.dissco.core.datacitepublisher.security;
 
 
-import eu.dissco.core.datacitepublisher.Profiles;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.actuate.autoconfigure.security.servlet.EndpointRequest;
 import org.springframework.boot.actuate.health.HealthEndpoint;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -16,7 +14,6 @@ import org.springframework.security.web.SecurityFilterChain;
 @RequiredArgsConstructor
 @Configuration
 @EnableWebSecurity
-@Profile({Profiles.PUBLISH, Profiles.WEB})
 public class WebSecurityConfig  {
 
   private final JwtAuthConverter jwtAuthConverter;


### PR DESCRIPTION
WebSecurityFilterChain needs to be on all profiles -- otherwise it locks the health endpoints and k8 kills the pod :hocho: 

note: We currently have the `test` profile on acceptance. 

Also updates our workflow file to:
- run every week
- include gitleaks
